### PR TITLE
Describe how to obtain the filename length from Fortran

### DIFF
--- a/html/RM/H5F/H5Fget_name.htm
+++ b/html/RM/H5F/H5Fget_name.htm
@@ -50,10 +50,9 @@
 	    that value plus one (1) can then be assigned to <code>size</code> 
 	    for a second <code>H5Fget_name</code> call, 
 	    which will retrieve the actual name. 
-	    In the Fortran API (where passing NULL is not possible), a string
-	    of any length may be passed in this preliminary call and the
-	    filename length will be assigned to <code>size</code> as in the C
-	    API. 
+	    In the Fortran API (where passing NULL is not possible), passing
+	    any length string in the preliminary call will result in the
+	    filename length being assigned to <code>size</code>.
             (The value passed in with the parameter <code>size</code> must be 
             one greater than size in bytes of the actual name in order to
             accommodate the null terminator; if <code>size</code> is set to

--- a/html/RM/H5F/H5Fget_name.htm
+++ b/html/RM/H5F/H5Fget_name.htm
@@ -50,6 +50,10 @@
 	    that value plus one (1) can then be assigned to <code>size</code> 
 	    for a second <code>H5Fget_name</code> call, 
 	    which will retrieve the actual name. 
+	    In the Fortran API (where passing NULL is not possible), a string
+	    of any length may be passed in this preliminary call and the
+	    filename length will be assigned to <code>size</code> as in the C
+	    API. 
             (The value passed in with the parameter <code>size</code> must be 
             one greater than size in bytes of the actual name in order to
             accommodate the null terminator; if <code>size</code> is set to


### PR DESCRIPTION
Added a sentence to H5Fget_name.htm describing how to obtain the filename length from Fortran. Addresses HDFGroup/hdf5#824.